### PR TITLE
added the posibility to assign host name

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -12,6 +12,10 @@ export class Config {
         return Config.configuration.get(val) as T;
     }
 
+    public static get getHost(): string {
+        return Config.getSettings<string>('host');
+    }
+
     public static get getPort(): number {
         return Config.getSettings<number>('port');
     }

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -133,7 +133,7 @@ export class AppModel {
     }
 
     private openBrowser(port: number, path: string) {
-        const host = '127.0.0.1';
+        const host = Config.getHost || 'localhost';
 
         let appConfig: string[] = [];
         let advanceCustomBrowserCmd = Config.getAdvancedBrowserCmdline;


### PR DESCRIPTION
Sometimes I need to connect to localhost.
By defaults other extensions also use localhost.
I added the posibility to change host name in settings and replaced '127.0.0.1' by 'localhost'