### PR TITLE
add basic mount directories as routes support

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,11 @@
           ],
           "description": "To ignore specific file changes"
         },
+        "liveServer.settings.mount": {
+          "type": "array",
+          "default": [],
+          "description": "Mount a directory to a route. Such as [['/components', './node_modules']]"
+        },
         "liveServer.settings.donotShowInfoMsg": {
           "type": "boolean",
           "default": false,

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -92,4 +92,8 @@ export class Config {
     public static get getfullReload(): boolean {
         return Config.getSettings<boolean>('fullReload');
     }
+
+    public static get getMount(): Array<Array<string>> {
+        return Config.getSettings<Array<Array<string>>>('mount');
+    }
 }

--- a/src/Helper.ts
+++ b/src/Helper.ts
@@ -93,6 +93,15 @@ export class Helper {
         });
         const proxy = Helper.getProxySetup();
         const https = Helper.getHttpsSetup();
+        const mount = Config.getMount;
+        // In live-server mountPath is reslove by `path.resolve(process.cwd(), mountRule[1])`.
+        // but in vscode `process.cwd()` is the vscode extensions path.
+        // The correct path should be resolve by workspacePath.
+        mount.forEach((mountRule) => {
+            if (mountRule[1]) {
+                mountRule[1] = path.resolve(workspacePath, mountRule[1]);
+            }
+        });
         return {
             port: port,
             host: '0.0.0.0',
@@ -107,7 +116,8 @@ export class Helper {
             wait: Config.getWait || 100,
             fullReload: Config.getfullReload,
             useBrowserExtension: Config.getUseWebExt,
-            onTagMissedCallback: onTagMissedCallback
+            onTagMissedCallback: onTagMissedCallback,
+            mount: mount
         };
     }
 


### PR DESCRIPTION
I find the live-server has [`mount` param](https://github.com/tapio/live-server#usage-from-node), so to support mount directories as routes  just need to add an option .

add config :

```js
"liveServer.settings.mount": [
        ["/ep920", "./"]
 ]
```

out put at vscode's console:

![image](https://user-images.githubusercontent.com/13060680/35898976-b78bbd3c-0c04-11e8-92d5-9e10331cd88d.png)

and it works well.
