### PR TITLE
Fix(#88): Adding an option for use local IP as host

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -159,3 +159,9 @@
     ```
 
     <hr>
+
+* **`liveServer.settings.useLocalIp:`** : Use local IP as host.
+    
+    * Default: `false`
+
+    <hr>

--- a/lib/live-server/package.json
+++ b/lib/live-server/package.json
@@ -43,6 +43,10 @@
     "node": ">=0.10.0"
   },
   "eslintConfig": {
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module"
+    },
     "env": {
       "node": true
     },

--- a/package.json
+++ b/package.json
@@ -176,6 +176,11 @@
           "default": "127.0.0.1",
           "description": "To switch between localhost or 127.0.0.1 or anything else. Default is 127.0.0.1"
         },
+        "liveServer.settings.useLocalIp": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use local IP as host"
+        },
         "liveServer.settings.proxy": {
           "type": "object",
           "default": {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -29,6 +29,10 @@ export class Config {
         return Config.getSettings<string>('host');
     }
 
+    public static get getLocalIp(): string {
+        return Config.getSettings<string>('useLocalIp');
+    }
+
     public static get getPort(): number {
         return Config.getSettings<number>('port');
     }

--- a/src/Helper.ts
+++ b/src/Helper.ts
@@ -2,6 +2,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 import { Config } from './Config';
 
 export const SUPPRORTED_EXT: string[] = [
@@ -150,5 +151,8 @@ export class Helper {
         return proxy;
     }
 
-
+    public static getEthernetInfo() {
+        var interfaces = os.networkInterfaces();
+        return interfaces['Ethernet'][1];
+    }
 }

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -15,8 +15,10 @@ export class AppModel {
     private IsStaging: boolean;
     private LiveServerInstance;
     private runningPort: number;
+    private localIp: String;
 
     constructor() {
+        this.localIp = Helper.getEthernetInfo().address;
         this.IsServerRunning = false;
         this.runningPort = null;
 
@@ -156,7 +158,7 @@ export class AppModel {
     }
 
     private openBrowser(port: number, path: string) {
-        const host = Config.getHost;
+        const host = Config.getLocalIp ? this.localIp : Config.getHost;
         const protocol = Config.getHttps.enable ? 'https' : 'http';
 
         let params: string[] = [];


### PR DESCRIPTION
Added Ethernet address along with configuration. I have prepared this PR for #88 but without using `node-ip`.