### PR TITLE
Option to hide statusbar button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "JLiveServer",
+  "name": "LiveServer",
   "displayName": "Live Server",
   "description": "Launch a development local Server with live reload feature for static & dynamic pages",
   "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "LiveServer",
+  "name": "JLiveServer",
   "displayName": "Live Server",
   "description": "Launch a development local Server with live reload feature for static & dynamic pages",
   "version": "3.2.1",
@@ -133,6 +133,11 @@
           ],
           "default": null,
           "description": "Note: If it is not Null, It will override CustomBrowser and ChromeDebuggingAttachment settings.\n\n Examples : \nchrome --incognito --headless --remote-debugging-port=9222 \n C:\\\\Program Files\\\\Firefox Developer Edition\\\\firefox.exe --private-window"
+        },
+        "liveServer.settings.showOnStatusbar": {
+          "type": "boolean",
+          "default": true,
+          "description": "Change this to false if you don't want the button to show in the statusbar"
         },
         "liveServer.settings.NoBrowser": {
           "type": "boolean",

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -75,7 +75,7 @@ export class Config {
 
     public static get getUseWebExt(): boolean {
         return Config.getSettings<boolean>('useWebExt') || false;
-    }
+	}
 
     public static get getProxy(): IProxy {
         return Config.getSettings<IProxy>('proxy');
@@ -95,5 +95,9 @@ export class Config {
 
     public static get getMount(): Array<Array<string>> {
         return Config.getSettings<Array<Array<string>>>('mount');
-    }
+	}
+		
+	public static get getShowOnStatusbar(): boolean {
+		return Config.getSettings<boolean>('showOnStatusbar') || false;
+	}
 }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -96,7 +96,7 @@ export class Config {
     public static get getMount(): Array<Array<string>> {
         return Config.getSettings<Array<Array<string>>>('mount');
     }
-		
+
     public static get getShowOnStatusbar(): boolean {
         return Config.getSettings<boolean>('showOnStatusbar') || false;
     }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -75,7 +75,7 @@ export class Config {
 
     public static get getUseWebExt(): boolean {
         return Config.getSettings<boolean>('useWebExt') || false;
-	}
+    }
 
     public static get getProxy(): IProxy {
         return Config.getSettings<IProxy>('proxy');
@@ -95,9 +95,9 @@ export class Config {
 
     public static get getMount(): Array<Array<string>> {
         return Config.getSettings<Array<Array<string>>>('mount');
-	}
+    }
 		
-	public static get getShowOnStatusbar(): boolean {
-		return Config.getSettings<boolean>('showOnStatusbar') || false;
-	}
+    public static get getShowOnStatusbar(): boolean {
+        return Config.getSettings<boolean>('showOnStatusbar') || false;
+    }
 }

--- a/src/StatusbarUi.ts
+++ b/src/StatusbarUi.ts
@@ -1,11 +1,11 @@
 import { StatusBarItem, window, StatusBarAlignment } from 'vscode';
-
+import { Config } from './Config';
 export class StatusbarUi {
 
     private static _statusBarItem: StatusBarItem;
 
     private static get statusbar() {
-        if (!StatusbarUi._statusBarItem) {
+        if (!StatusbarUi._statusBarItem && Config.getShowOnStatusbar) {
             StatusbarUi._statusBarItem = window
                 .createStatusBarItem(StatusBarAlignment.Right, 100);
 


### PR DESCRIPTION
Maybe I haven't done this correctly because I'm a bit of a newbie to vscode extensions, and to contributing to code in general. 

I just thought there should be an option to hide the "Go Live" button in the statusbar, I can't disable the extension because it is dependency for Live Sass Compiler, but it's a button I don't need because in most workspaces I'm not using it directly.

I thought I'd try doing it myself...