### PR TITLE
Ignore typescript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,8 @@
           "default": [
             ".vscode/**",
             "**/*.scss",
-            "**/*.sass"
+            "**/*.sass",
+            "**/*.ts"
           ],
           "description": "To ignore specific file changes"
         },


### PR DESCRIPTION
When editing typescript files, the page reloads 2+ times:

* Once for when the typescript file gets saved
* Once for when the javascript file gets updated