### PR TITLE
feat: making tsconfig for multiple environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "LiveServer",
+  "name": "vscode-live-server",
   "displayName": "Live Server",
   "description": "Launch a development local Server with live reload feature for static & dynamic pages",
   "version": "4.0.0",
@@ -30,7 +30,7 @@
   "activationEvents": [
     "*"
   ],
-  "main": "./out/src/extension",
+  "main": "./build/src/extension",
   "contributes": {
     "commands": [
       {
@@ -292,8 +292,10 @@
   },
   "homepage": "https://ritwickdey.github.io/vscode-live-server/",
   "scripts": {
-    "vscode:prepublish": "tsc -p ./",
+    "vscode:prepublish": "tsc -p ./tsconfig.prod.json",
     "compile": "tsc -watch -p ./",
+    "dev:compile": "tsc -watch -p ./tsconfig.dev.json",
+    "prod:compile": "tsc -watch -p ./tsconfig.prod.json",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test",
     "lint": "tslint --project ."

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "activationEvents": [
     "*"
   ],
-  "main": "./build/src/extension",
+  "main": "./out/src/extension",
   "contributes": {
     "commands": [
       {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vscode-live-server",
+  "name": "LiveServer",
   "displayName": "Live Server",
   "description": "Launch a development local Server with live reload feature for static & dynamic pages",
   "version": "4.0.0",

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -1,0 +1,6 @@
+{
+    "extends": "./tsconfig",
+    "compilerOptions": {
+        "sourceMap": true
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,12 +6,15 @@
         "lib": [
             "es6"
         ],
-        "sourceMap": true,
         "rootDir": "."
     },
     "exclude": [
         "node_modules",
         ".vscode-test",
-        "_site"
+        "_site",
+        "docs",
+        "images",
+        "out",
+        ".vscode"
     ]
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig",
+    "compilerOptions": {
+        "sourceMap": false
+    },
+    "exclude": [
+        "test"
+    ]
+}


### PR DESCRIPTION
- New Feature: No
- Fix typo: No
- Modify: Yes

***Description***

1) Making tsconfig for multiple environment(`production` and `development`)
2) Previously `out` directory was `49.9kb`(with source map) now `21.8kb`(without source map) after compilation.
3) Removed test folder for `production`.