### PR TITLE
added blisk browser as custom browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
             "firefox",
             "firefox:PrivateMode",
             "microsoft-edge",
-            "null"
+            "blisk",
+            "blisk:PrivateMode"
           ]
         },
         "liveServer.settings.ChromeDebuggingAttachment": {

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -216,13 +216,13 @@ export class AppModel {
                 params.push(browserName);
 
                 if (browserDetails[1] && browserDetails[1] === 'PrivateMode') {
-                    if (browserName === 'chrome')
+                    if (browserName === 'chrome' || browserName === 'blisk')
                         params.push('--incognito');
                     else if (browserName === 'firefox')
                         params.push('--private-window');
                 }
 
-                if (browserName === 'chrome' && ChromeDebuggingAttachmentEnable) {
+                if ((browserName === 'chrome' || browserName === 'blisk') && ChromeDebuggingAttachmentEnable) {
                     params.push(...[
                         '--new-window',
                         '--no-default-browser-check',
@@ -248,8 +248,7 @@ export class AppModel {
                     params[0] = 'chrome';
 
             }
-        }
-        else if (params[0] && params[0].startsWith('microsoft-edge')) {
+        } else if (params[0] && params[0].startsWith('microsoft-edge')) {
             params[0] = `microsoft-edge:${protocol}://${host}:${port}/${path}`;
         }
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```html
[ ] Bugfix
[x] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other: <!-- Please describe: -->
```

## What is the current behavior?

- Blisk wasn't in the custom browser list.

Issue Number: #51 

## What is the new behavior?

- Added blisk browser as a custom browser

## Does this PR introduce a breaking change?

```text
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Running on blisk with private window (--incognito flag) crashing on my system.