### PR TITLE
Integration with VS Live Share

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
             "outFiles": [
                 "${workspaceRoot}/out/src/**/*.js"
             ],
-            "preLaunchTask": "npm"
+            "preLaunchTask": "build"
         },
         {
             "name": "Launch Tests",
@@ -31,7 +31,7 @@
             "outFiles": [
                 "${workspaceRoot}/out/test/**/*.js"
             ],
-            "preLaunchTask": "npm"
+            "preLaunchTask": "build"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,23 +8,31 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-    "version": "0.1.0",
-
-    // we want to run npm
-    "command": "npm",
-
-    // the command is a shell script
-    "isShellCommand": true,
-
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
-
-    // we run the custom script "compile" as defined in package.json
-    "args": ["run", "compile", "--loglevel", "silent"],
-
-    // The tsc compiler is started in watching mode
-    "isBackground": true,
-
-    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      // the command is a shell script
+      "type": "shell",
+      // show the output window only if unrecognized errors occur.
+      "presentation": {
+        "reveal": "silent",
+        "focus": false,
+        "panel": "shared",
+      },
+      // we run the custom script "compile" as defined in package.json
+      "command": "npm",
+      "args": ["run", "compile", "--loglevel", "silent"],
+      // The tsc compiler is started in watching mode
+      "isBackground": true,
+      // use the standard tsc in watch mode problem matcher to find compile problems in the output.
+      "problemMatcher": [
+        "$tsc-watch"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+    }
+  ]
 }

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -153,8 +153,8 @@
     ```js
     {
         "liveServer.settings.mount:" [
-            ["/", "/path1"]
-            ["/", "/path2"]
+            ["/", "/path1"],
+            ["/", "/path2"],
             ["/root", "/dist"]
         ]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3343,6 +3343,11 @@
         }
       }
     },
+    "vsls": {
+      "version": "0.3.896",
+      "resolved": "https://registry.npmjs.org/vsls/-/vsls-0.3.896.tgz",
+      "integrity": "sha512-4AB31GVEtR7043byw7JL8z0Bpj7MRCIyPorJXHQqzx3EUpAnGKR1jinFeiYEQSQxr1J5zVPXPHOB7+6Hiv0VlQ=="
+    },
     "websocket-driver": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -338,7 +338,8 @@
     "http-shutdown": "^1.2.0",
     "ips": "^2.1.3",
     "live-server": "file:lib\\live-server",
-    "opn": "^5.3.0"
+    "opn": "^5.3.0",
+    "vsls": "^0.3.896"
   },
   "announcement": {
     "onVersion": "5.0.0",

--- a/src/IAppModel.ts
+++ b/src/IAppModel.ts
@@ -1,0 +1,18 @@
+'use strict';
+
+import { Event } from 'vscode';
+
+export interface GoLiveEvent {
+    readonly runningPort: number;
+    readonly pathUri?: string;
+}
+
+export interface GoOfflineEvent {
+    readonly runningPort: number;
+}
+
+export interface IAppModel {
+    readonly runningPort: number;
+    readonly onDidGoLive: Event<GoLiveEvent>;
+    readonly onDidGoOffline: Event<GoOfflineEvent>;
+}

--- a/src/LiveShareHelper.ts
+++ b/src/LiveShareHelper.ts
@@ -1,0 +1,72 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as vsls from 'vsls/vscode';
+import { IAppModel, GoLiveEvent, GoOfflineEvent } from './IAppModel';
+
+/**
+ * Manages state of a live server shared via VS Live Share.
+ * Caches the live server path and starts/stops sharing in response to Live Share session events.
+ */
+export class LiveShareHelper implements vscode.Disposable {
+    private liveshare: vsls.LiveShare | undefined;
+    private activeHostSession: vsls.Session | undefined;
+    private livePathUri: string;
+
+    private deferredWork: Promise<void>;
+    private sharedServer: vscode.Disposable;
+
+    constructor(private readonly appModel: IAppModel) {
+        this.appModel.onDidGoLive(async (e: GoLiveEvent) => {
+            // cache the current live server browse url
+            this.livePathUri = e.pathUri;
+            await this.shareLiveServer();
+        });
+        this.appModel.onDidGoOffline((e: GoOfflineEvent) => {
+            // reset the live server cached path
+            this.livePathUri = null;
+            if (this.activeHostSession && this.sharedServer) {
+                // will un-share the server
+                this.sharedServer.dispose();
+                this.sharedServer = null;
+            }
+        });
+        this.deferredWork = vsls.getApi().then(api => {
+            if (api) { // if Live Share is available (installed)
+                this.ensureInitialized(api);
+            }
+        });
+    }
+
+    async dispose() {
+        await this.deferredWork;
+    }
+
+    private ensureInitialized(api: vsls.LiveShare) {
+        this.liveshare = api;
+        if (this.liveshare.session && this.liveshare.session.role === vsls.Role.Host) {
+            this.activeHostSession = this.liveshare.session;
+        }
+        this.liveshare.onDidChangeSession(async (e: vsls.SessionChangeEvent) => {
+            if (e.session.role === vsls.Role.Host) {
+                // active sharing collaboration session
+                this.activeHostSession = e.session;
+                await this.shareLiveServer();
+            } else {
+                // any other session state, including joined as a guest
+                this.activeHostSession = null;
+            }
+        });
+    }
+
+    private async shareLiveServer() {
+        if (this.activeHostSession && this.livePathUri) {
+            // only share the server when we're live and VS Live Share session is active
+            this.sharedServer = await this.liveshare.shareServer({
+                port: this.appModel.runningPort,
+                displayName: 'Live Server',
+                browseUrl: `http://localhost:${this.appModel.runningPort}/${this.livePathUri.replace(/\\/gi, '/')}`
+            });
+        }
+    }
+}


### PR DESCRIPTION
## PR Type

This PR is a proposed solution for integrating Visual Studio Live Share extension with Live Server extension that'd help to automate sharing a server in a collaboration session.

```html
[ ] Bugfix
[x] Feature
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other: <!-- Please describe: -->
```

## What is the current behavior?

This solution is a significant improvement in user experience as of today a user sharing a workspace in VSCode needs to share Live Server manually through the interactive flow every time.

## What is the new behavior?

With the new flow, upon the collaboration session start Live Server sends a request to share a live server. In response to the request, VS Live Share notifies the host user and requests their permission to start sharing the server.

![image](https://user-images.githubusercontent.com/8239356/48166156-8fcaac80-e29c-11e8-9aec-2ac849f3f9ba.png)

When the host user clicks the Allow button all participants in the collaboration session get access to the shared server.

![image](https://user-images.githubusercontent.com/8239356/48166383-3c0c9300-e29d-11e8-94e1-3b03a74c18b7.png)

## Does this PR introduce a breaking change?

```text
[ ] Yes
[x] No
```

## Other information

### Implementation Details

VS Live Share provides extensibility API allowing consumers to subscribe to collaboration session events and invoke methods to share/un-share artifacts in the active collaboration session. To help to manage live server sharing state I've introduced `LiveShareHelper` class that receives notifications from `AppModel` and VS Live Share API.
To decouple the helper from the model I've extracted `IAppModel` interface with two new events `GoLiveEvent` and `GoOfflineEvent`.

#### Misc
As `tasks.json` version `0.1.0` has been deprecated I upgraded the default build task definition to version `2.0.0` using a recommended task template.