### PR TITLE
Added chromium support in liveServer.settings.CustomBrowser

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,8 @@
           "enum": [
             "chrome",
             "chrome:PrivateMode",
+            "chromium",
+            "chromium:PrivateMode",
             "firefox",
             "firefox:PrivateMode",
             "microsoft-edge",

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -227,7 +227,7 @@ export class AppModel implements IAppModel {
         let useBrowserPreview = Config.getUseBrowserPreview;
         if (useBrowserPreview) {
             let url = `${protocol}://${host}:${port}/${path}`;
-            let onSuccess = () => {};
+            let onSuccess = () => { };
             let onError = (err) => {
                 this.showPopUpMsg(`Server is started at ${this.runningPort} but failed to open in Browser Preview. Got Browser Preview extension installed?`, true);
                 console.log('\n\nError Log to open Browser : ', err);
@@ -257,13 +257,13 @@ export class AppModel implements IAppModel {
                 params.push(browserName);
 
                 if (browserDetails[1] && browserDetails[1] === 'PrivateMode') {
-                    if (browserName === 'chrome' || browserName === 'blisk')
+                    if (browserName === 'chrome' || browserName === 'chromium' || browserName === 'blisk')
                         params.push('--incognito');
                     else if (browserName === 'firefox')
                         params.push('--private-window');
                 }
 
-                if ((browserName === 'chrome' || browserName === 'blisk') && ChromeDebuggingAttachmentEnable) {
+                if ((browserName === 'chrome' || browserName === 'chromium' || browserName === 'blisk') && ChromeDebuggingAttachmentEnable) {
                     params.push(...[
                         '--new-window',
                         '--no-default-browser-check',
@@ -287,6 +287,21 @@ export class AppModel implements IAppModel {
                     break;
                 default:
                     params[0] = 'chrome';
+
+            }
+        } else if (params[0] && params[0] === 'chromium') {
+            switch (process.platform) {
+                case 'darwin':
+                    params[0] = 'chromium';
+                    break;
+                case 'linux':
+                    params[0] = 'chromium';
+                    break;
+                case 'win32':
+                    params[0] = 'chromium';
+                    break;
+                default:
+                    params[0] = 'chromium';
 
             }
         } else if (params[0] && params[0].startsWith('microsoft-edge')) {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```html
[ ] Bugfix
[ x] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other: <!-- Please describe: -->
```

## What is the current behavior?
I was running vscode with liveserver in Debian 9. My default browser is chromium. When I put chromium or chromium:PrivateMode, liverserver will use non incognito mode for both.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Added chromium and chromium:PrivateMode into liveServer.settings.CustomBrowser setting.
Basically, the use can use chromium or chromium:PrivateMode with lint error.
## Does this PR introduce a breaking change?

```text
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Thank you for your time to review my request.