### PR TITLE
Update index.js

### DIFF
--- a/lib/live-server/index.js
+++ b/lib/live-server/index.js
@@ -59,7 +59,7 @@ function staticServer(root, onTagMissedCallback) {
 		var hasNoOrigin = !req.headers.origin;
 		var injectCandidates = [
 			new RegExp("</body>", "i"),
-			new RegExp("</svg>"),
+			new RegExp("</svg>\s$"), //captures only last instance of svg, since valid svg files can include multiple svg tags
 			new RegExp("</head>", "i")
 		];
 


### PR DESCRIPTION
Captures only the last instance of SVG. This is necessary since valid SVG files can include multiple SVG tags.
see: https://github.com/ritwickdey/vscode-live-server/issues/684

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```html
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other: <!-- Please describe: -->
```

## What is the current behavior?

Currently svg files with multiple svg tags are truncated by the server because the injection script is injected multiple times but only accounted for once in the http header content length.

Issue Number: 684

## What is the new behavior?
The injection script is only injected into an svg file once.
## Does this PR introduce a breaking change?

```text
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
