### PR TITLE
Fixing HTML validator warning

### DIFF
--- a/lib/live-server/injected.html
+++ b/lib/live-server/injected.html
@@ -1,5 +1,5 @@
 <!-- Code injected by live-server -->
-<script type="text/javascript">
+<script>
 	// <![CDATA[  <-- For SVG support
 	if ('WebSocket' in window) {
 		(function () {


### PR DESCRIPTION
The script type property is no longer needed and generates a warning when the HTML is validated using browser plugins.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```html
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other: <!-- Please describe: -->
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When pages are validated using the [Validity Plugin](https://chrome.google.com/webstore/detail/validity/bbicmjjbohdfglopkidebfccilipgeif?hl=en-US) browser extension. It flags the injected script with the warning shown below.

![image](https://user-images.githubusercontent.com/6501079/118548030-6c133780-b71f-11eb-9238-5ee1a57833f4.png)

Issue Number: N/A

## What is the new behavior?

With this change, the Live Server will not introduce HTML validation issues.

## Does this PR introduce a breaking change?

```text
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
