### PR TITLE
Remove /index.html from URL if at the end

### DIFF
--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -219,6 +219,10 @@ export class AppModel implements IAppModel {
         }
         path = path.replace(/\\/gi, '/');
 
+        if(path.endsWith("/index.html")){
+            path = path.slice(0,-11);
+        }
+
         let useBrowserPreview = Config.getUseBrowserPreview;
         if (useBrowserPreview) {
             let url = `${protocol}://${host}:${port}/${path}`;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

This PR removes `/index.html` from the end of the URL live server opens in the browser because it is unnecessary and only makes the URL longer.

<!-- Please check the one that applies to this PR using "x". -->

```html
[ ] Bugfix
[ ] Feature
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other: <!-- Please describe: -->
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Live server opens my html page in the browser with the URL `127.0.0.1:5500/index.html`

Issue Number: N/A

## What is the new behavior?

Live server opens my html page in the browser with the URL `127.0.0.1:5500`

## Does this PR introduce a breaking change?

```text
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
