### PR TITLE
fix: NoBrowser when server is running

### DIFF
--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -60,10 +60,13 @@ export class AppModel implements IAppModel {
         if (this.IsServerRunning) {
             const relativePath = Helper.getSubPath(pathInfos.rootPath, openedDocUri) || '';
             this.goLiveEvent.fire({ runningPort: this.runningPort, pathUri: relativePath });
-            return this.openBrowser(
-                this.runningPort,
-                relativePath
-            );
+            if (!Config.getNoBrowser) {
+              return this.openBrowser(
+                  this.runningPort,
+                  relativePath
+              );
+            }
+            return;
         }
         if (pathInfos.isNotOkay) {
             this.showPopUpMsg('Invalid Path in liveServer.settings.root settings. live Server will serve from workspace root', true);


### PR DESCRIPTION
When the NoBrowser setting is true, a browser should not be opened even if the server is already running. The existing version doesn't open a browser the first time the server starts, but then does open a one if the goOnline command is called again.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```html
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other: <!-- Please describe: -->
```

## What is the current behavior?

Issue Number: #2673 

## What is the new behavior?

A browser is never opened when the NoBrowser option is set to true.

## Does this PR introduce a breaking change?

```text
[ ] Yes
[x] No
```
