### PR TITLE
Prioritize injecting into head tag over

### DIFF
--- a/lib/live-server/index.js
+++ b/lib/live-server/index.js
@@ -61,10 +61,10 @@ function staticServer(root, onTagMissedCallback) {
 		if (req.method !== "GET" && req.method !== "HEAD") return next();
 		var reqpath = isFile ? "" : url.parse(req.url).pathname;
 		var hasNoOrigin = !req.headers.origin;
-		var injectCandidates = [
+		var injectCandidates = [ // The array order determines candidate priority
+			new RegExp("</head>", "i"),
 			new RegExp("</body>", "i"),
 			new RegExp("</svg>"),
-			new RegExp("</head>", "i")
 		];
 
 		// extraInjectCandidates = extraInjectCandidates || [];


### PR DESCRIPTION
This fixes https://github.com/ritwickdey/vscode-live-server/issues/2687

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```html
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other: <!-- Please describe: -->
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 2687

## What is the new behavior?

If there is both a `</svg>` and a `</head>`, inject into the head instead of the svg.

## Does this PR introduce a breaking change?

```text
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
