### PR TITLE
Inject code to last candidate

### DIFF
--- a/lib/live-server/index.js
+++ b/lib/live-server/index.js
@@ -62,9 +62,9 @@ function staticServer(root, onTagMissedCallback) {
 		var reqpath = isFile ? "" : url.parse(req.url).pathname;
 		var hasNoOrigin = !req.headers.origin;
 		var injectCandidates = [
-			new RegExp("</body>", "i"),
+			new RegExp(/<\/body>(?![\s\S]*<\/body>[\s\S]*$)/i),
 			new RegExp("</svg>"),
-			new RegExp("</head>", "i")
+			new RegExp(/<\/head>(?![\s\S]*<\/head>[\s\S]*$)/i)
 		];
 
 		// extraInjectCandidates = extraInjectCandidates || [];


### PR DESCRIPTION
Rather than injecting into the first match of "</body>" , it will inject into the last found occurrence of it. This will avoid overwriting code following the tag. Also works for the head regex.

## PR Type

What kind of change does this PR introduce?

Fix injection candidate regex

<!-- Please check the one that applies to this PR using "x". -->

```html
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other: <!-- Please describe: -->
```

## What is the current behavior?

matches the first occurrence of a tag and overrides code

Issue Number: N/A (there were multiple issues referring to this issue)

## What is the new behavior?

matches the last occurrence of a tag

## Does this PR introduce a breaking change?

```text
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
