### PR TITLE
Added Firefox Developer Edition in the CustomBrowser

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
             "chrome:PrivateMode",
             "firefox",
             "firefox:PrivateMode",
+            "Firefox Developer Edition",
             "microsoft-edge",
             "blisk",
             null


### PR DESCRIPTION
Currently, you can use the setting `"liveServer.settings.CustomBrowser": "Firefox Developer Edition"`, and it will work perfectly fine, but it shows an Warning. 
This will fix it.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```html
[x] Bugfix
[x] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other: <!-- Please describe: -->
```

## What is the current behavior?
It only shows Firefox, not the Developer Edition of it.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
It will show the Firefox Developer Edition as a normal setting.

## Does this PR introduce a breaking change?

```text
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
