### PR TITLE
fix:  server binding 0.0.0.0 for useLocalIp only

### DIFF
--- a/src/Helper.ts
+++ b/src/Helper.ts
@@ -108,7 +108,7 @@ export class Helper {
         const file = Config.getFile;
         return {
             port: port,
-            host: '0.0.0.0',
+            host: Config.getLocalIp ? '0.0.0.0' : Config.getHost,
             root: rootPath,
             file: file,
             open: false,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

Set the binding host to 0.0.0.0 only the user sets useLocalIp = true. Otherwise, users may mistakenly assume that the website can only be accessed locally, when in fact it is anonymously accessible throughout the entire LAN, which could create a security vulnerability.

```html
[X] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other: <!-- Please describe: -->
```

## What is the current behavior?

Live server is always binding to 0.0.0.0 (include localhost IP and all network adapter IP)

Issue Number: N/A

## What is the new behavior?

When user set useLocalIp = true, live server bind to host 0.0.0.0, otherwise it bind to the setting from Config.getHost.

## Does this PR introduce a breaking change?

```text
[X] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

According to the existing documentation, users would understand that without setting "useLocalIp", access is limited to the local machine. However, the current situation opens up unused external access, and this change should not affect existing usage.

## Other information
