### PR TITLE
feat: add ability to set additional response headers

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -182,3 +182,19 @@
     
     * Tips: You don't need to set this setting, Live Server is smart enough, it'll eigher ask what you want or automatically set the correct workspace if open the server by right clicking any HTML file.    
     <hr>
+
+* **`liveServer.settings.headers:`** : Add additional headers.
+
+    * Default: `{}`
+
+    * Example:
+    ```js
+    {
+        "liveServer.settings.headers": {
+            "Cross-Origin-Opener-Policy": "same-origin",
+            "Cross-Origin-Embedder-Policy": "require-corp"
+        }
+    }
+    ```
+    
+    <hr>

--- a/lib/live-server/index.js
+++ b/lib/live-server/index.js
@@ -153,6 +153,23 @@ function entryPoint(staticHandler, file) {
 }
 
 /**
+ * 
+ * @param {Object} headers 
+ * @returns {Function} Middleware function
+ */
+function setHeadersMiddleware(headers) {
+	return function (_, res, next) {
+		if (headers && typeof headers === 'object' && !Array.isArray(headers)) {
+			for (let header in headers) {
+				res.setHeader(header, headers[header]);
+			}
+		}
+
+		next();
+	}
+}
+
+/**
  * Start a live server with parameters given as an object
  * @param host {string} Address to bind to (default: 0.0.0.0)
  * @param port {number} Port number (default: 8080)
@@ -167,6 +184,7 @@ function entryPoint(staticHandler, file) {
  * @param wait {number} Server will wait for all changes, before reloading
  * @param htpasswd {string} Path to htpasswd file to enable HTTP Basic authentication
  * @param middleware {array} Append middleware to stack, e.g. [function(req, res, next) { next(); }].
+ * @param headers {object} Additional headers to set on all responses, e.g. { "Cross-Origin-Opener-Policy": "same-origin" }
  */
 LiveServer.start = function (options, callback) {
 	options = options || {};
@@ -193,11 +211,15 @@ LiveServer.start = function (options, callback) {
 	var disableGlobbing = options.disableGlobbing || false;
 	var onTagMissedCallback = options.onTagMissedCallback || null;
 	var fullReload = options.fullReload || false;
+	var headers = options.headers || {};
 
 	var staticServerHandler = staticServer(root, onTagMissedCallback);
 
 	// Setup a web server
 	var app = connect();
+
+	// Set additional headers
+	app.use(setHeadersMiddleware(headers));
 
 	// Add logger. Level 2 logs only errors
 	if (LiveServer.logLevel === 2) {

--- a/package.json
+++ b/package.json
@@ -295,6 +295,11 @@
           "type": "string",
           "default": null,
           "description": "This the entry point of server when you're in multiroot workspace"
+        },
+        "liveServer.settings.headers": {
+          "type": "object",
+          "default": {},
+          "description": "Add additional headers"
         }
       }
     }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -124,4 +124,8 @@ export class Config {
     public static setMultiRootWorkspaceName(val: string) {
        return Config.configuration.update('multiRootWorkspaceName', val, false);
     }
+
+    public static get getHeaders(): Record<string, string> | undefined {
+        return Config.getSettings<Record<string, string> | undefined>('headers');
+    }
 }

--- a/src/Helper.ts
+++ b/src/Helper.ts
@@ -83,6 +83,7 @@ export class Helper {
 
         workspacePath = workspacePath || '';
         const port = Config.getPort;
+        const headers = Config.getHeaders || {};
         const ignorePathGlob = Config.getIgnoreFiles || [];
 
         const ignoreFiles = [];
@@ -121,7 +122,8 @@ export class Helper {
             fullReload: Config.getfullReload,
             useBrowserExtension: Config.getUseWebExt,
             onTagMissedCallback: onTagMissedCallback,
-            mount: mount
+            mount: mount,
+            headers: headers
         };
     }
 


### PR DESCRIPTION
What kind of change does this PR introduce?

```html
[ ] Bugfix
[X] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other
```

## What is the current behavior?

The Live Server extension does not offer a way to configure custom HTTP response headers, which can limit functionality for developers who rely on specific headers.

For example, when using the `sqlite-wasm` library, it is necessary to provide the following headers:

```
Cross-Origin-Opener-Policy: same-origin
Cross-Origin-Embedder-Policy: require-corp
```

Without these headers, the browser will block access to the WebAssembly module due to security restrictions.

## What is the new behavior?

This PR adds support for configurable HTTP response headers through a new `liveServer.settings.headers` configuration option. Users can now specify custom headers in their VS Code settings that will be applied to all server responses.

**Example usage:**
```json
{
    "liveServer.settings.headers": {
        "Cross-Origin-Opener-Policy": "same-origin",
        "Cross-Origin-Embedder-Policy": "require-corp"
    }
}
```

Issue Number: N/A

## Does this PR introduce a breaking change?

[ ] Yes
[X] No