### PR TITLE
Update README to remove beta reference and spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 3. Open a HTML file and right-click on the editor and  click on `Open with Live Server`.
 ![Edit Menu Option Preview](./images/Screenshot/vscode-live-server-editor-menu-3.jpg)
 
-4. Hit `(alt+L, alt+O)` to Open the Server and `(alt+L, alt+C)` to Stop the server (You can change the shortcut from keybinding). *[On MAC, `cmd+L, cmd+O` and `cmd+L, cmd+C`]*
+4. Hit `(alt+L, alt+O)` to Open the Server and `(alt+L, alt+C)` to Stop the server (You can change the shortcut in Keyboard Shortcuts / keybindings (Preferences → Open Keyboard Shortcuts)). *[On macOS, `cmd+L, cmd+O` and `cmd+L, cmd+C`]*
 
 5. Open the Command Palette by pressing `F1` or `ctrl+shift+P` and type `Live Server: Open With Live Server ` to start a server or type `Live Server: Stop Live Server` to stop a server.
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ _[Wanna try [LIVE SERVER++](https://github.com/ritwickdey/vscode-live-server-plu
 3. Open a HTML file and right-click on the editor and  click on `Open with Live Server`.
 ![Edit Menu Option Preview](./images/Screenshot/vscode-live-server-editor-menu-3.jpg)
 
-4. Hit `(alt+L, alt+O)` to Open the Server and `(alt+L, alt+C)` to Stop the server (You can change the shortcut form keybinding). *[On MAC, `cmd+L, cmd+O` and `cmd+L, cmd+C`]*
+4. Hit `(alt+L, alt+O)` to Open the Server and `(alt+L, alt+C)` to Stop the server (You can change the shortcut from keybinding). *[On MAC, `cmd+L, cmd+O` and `cmd+L, cmd+C`]*
 
-5. Open the Command Pallete by pressing `F1` or `ctrl+shift+P` and type `Live Server: Open With Live Server ` to start a server or type `Live Server: Stop Live Server` to stop a server.
+5. Open the Command Palette by pressing `F1` or `ctrl+shift+P` and type `Live Server: Open With Live Server ` to start a server or type `Live Server: Stop Live Server` to stop a server.
 
 
 ## Features
@@ -70,7 +70,7 @@ All settings are now listed here  [Settings Docs](./docs/settings.md).
   * Fixed `Extension host terminated unexpectedly` *[[#431](https://github.com/ritwickdey/vscode-live-server/issues/431)]*
 
 * ### Version 5.6.0 (17.04.19)
-  * ***[NEW]*** Intregation of `Browser Preview` with `Live Server` *[[#352](https://github.com/ritwickdey/vscode-live-server/pull/352) - Thanks to [Kenneth Auchenberg](https://github.com/auchenberg)]*
+  * ***[NEW]*** Integration of `Browser Preview` with `Live Server` *[[#352](https://github.com/ritwickdey/vscode-live-server/pull/352) - Thanks to [Kenneth Auchenberg](https://github.com/auchenberg)]*
   * ***[NEW]*** Fallback to random port If given port is busy. *[[#330](https://github.com/ritwickdey/vscode-live-server/pull/330) - Thanks to [Ali Almohaya](https://github.com/Almo7aya) ]*
   * ***[FIXES]***  Moved to `vscode-chokidar` lib for *[#285](https://github.com/ritwickdey/vscode-live-server/issues/285)*.
   * Doc Fixes  *[[#388](https://github.com/ritwickdey/vscode-live-server/pull/388) - Thanks to [Ted Silbernagel](https://github.com/tedsilb)]*
@@ -90,7 +90,7 @@ To check full changelog [click here](CHANGELOG.md).
 
 
 ## Special Thanks To Maintainers
-A special thanks to [Max Schmitt](https://github.com/mxschmitt), [Joydip Roy](https://github.com/rjoydip) & [Ayo Adesugba](https://github.com/adesugbaa) for contributing their valueable time on this project.
+A special thanks to [Max Schmitt](https://github.com/mxschmitt), [Joydip Roy](https://github.com/rjoydip) & [Ayo Adesugba](https://github.com/adesugbaa) for contributing their valuable time on this project.
 
 [![Max Schmitt](https://avatars2.githubusercontent.com/u/17984549?s=64)](https://github.com/mxschmitt)
 [![Joydip Roy](https://avatars2.githubusercontent.com/u/15318294?s=64)](https://github.com/rjoydip)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-_[Wanna try [LIVE SERVER++](https://github.com/ritwickdey/vscode-live-server-plus-plus) (BETA) ? It'll enable live changes without saving file.  https://github.com/ritwickdey/vscode-live-server-plus-plus ]_
-
 # Live Server
 
 **Live Server loves** 💘 **your multi-root workspace**


### PR DESCRIPTION
Similar to ChrisKaders concerns (the first two lines are heavily outdated). And some simple spelling fixes.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```html
[ ] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other: <!-- Please describe: -->
```

## What is the current behavior?

The README.md includes links directing users to a "Beta" repo that has not been updated in 7 years. The README.md also includes minor spelling errors.

Issue Number: N/A

## What is the new behavior?

The README.md has been updated to remove the links to the "Beta" repo. The spelling errors have been corrected.

## Does this PR introduce a breaking change?

```text
[ ] Yes
[x] No
```

## Other information

Thanks to ChrissKaders for spotting the outdated link. 
