### PR TITLE
patch: fix script injection location

### DIFF
--- a/lib/live-server/index.js
+++ b/lib/live-server/index.js
@@ -62,9 +62,9 @@ function staticServer(root, onTagMissedCallback) {
 		var reqpath = isFile ? "" : url.parse(req.url).pathname;
 		var hasNoOrigin = !req.headers.origin;
 		var injectCandidates = [
-			new RegExp("</body>", "i"),
-			new RegExp("</svg>"),
-			new RegExp("</head>", "i")
+			{ regex: new RegExp("</body>", "i"), lastOccurrence: true },
+			{ regex: new RegExp("</svg>"), lastOccurrence: true },
+			{ regex: new RegExp("</head>", "i"), lastOccurrence: false }
 		];
 
 		// extraInjectCandidates = extraInjectCandidates || [];
@@ -88,11 +88,18 @@ function staticServer(root, onTagMissedCallback) {
 			if (hasNoOrigin && (possibleExtensions.indexOf(x) > -1)) {
 				// TODO: Sync file read here is not nice, but we need to determine if the html should be injected or not
 				var contents = fs.readFileSync(filepath, "utf8");
+				var lastIndex = -1;
 				for (var i = 0; i < injectCandidates.length; ++i) {
-					match = injectCandidates[i].exec(contents);
-					if (match) {
-						injectTag = match[0];
-						break;
+					var allMatches = [...contents.matchAll(injectCandidates[i].regex)];
+					if (allMatches.length > 0) {
+						var selectedMatch = injectCandidates[i].lastOccurrence
+							? allMatches[allMatches.length - 1]
+							: allMatches[0];
+						var matchIndex = selectedMatch.index;
+						if (matchIndex > lastIndex) {
+							lastIndex = matchIndex;
+							injectTag = selectedMatch[0];
+						}
 					}
 				}
 


### PR DESCRIPTION
Use the last matched pattern for </body> and </svg> to locate script injection location, to avoid breaking application code.

- fix https://github.com/ritwickdey/vscode-live-server/issues/3280

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```html
[x] Bugfix
[ ] Feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other: <!-- Please describe: -->
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The current script injection looks for the first occurrence of the `</body>` pattern, which may break application code if the user written `</body>` as part of a string value.

Issue Number: https://github.com/ritwickdey/vscode-live-server/issues/3280

## What is the new behavior?

It looks for the last occurrence of  `</body>` (instead of the first occurrence) for the script injection.

## Does this PR introduce a breaking change?

```text
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
It passed all test cases (`test:lint`, `test:unit`, and `test:e2e`).

## Other information

Patched wdio-vscode-service launcher to use ChromeDriver 142.0.7444.265 (matching VS Code 1.113.0's embedded Chrome) for the e2e test to run properly. Otherwise I below error:
```
SevereServiceError: Couldn't set up Chromedriver Response code 404 (Not Found)
```